### PR TITLE
Added option new parameter to 'Create FortiSOAR Attachment' 

### DIFF
--- a/docs/HikvisionNVRDoc.md
+++ b/docs/HikvisionNVRDoc.md
@@ -303,7 +303,9 @@ The output contains the following populated JSON schema:
 #### Input parameters
 <table border=1><thead><tr><th>Parameter</th><th>Description</th></tr></thead><tbody><tr><td>Channel ID</td><td>Specify the ID of the channel from which you want to download the video recording.
 </td></tr><tr><td>Video Name</td><td>Specify the name of the video recording which you want to download
+</td></tr><tr><td>Create FortiSOAR Attachments</td><td>SIf the user wants to create an Attachment record in the FortiSAOR attachment module, then select this option. Otherwise, it stores the recording in the /tmp directory
 </td></tr></tbody></table>
+
 #### Output
 The output contains the following populated JSON schema:
 

--- a/docs/HikvisionNVRDoc.md
+++ b/docs/HikvisionNVRDoc.md
@@ -8,7 +8,7 @@ Connector Version: 1.0.0
 
 Contributors: Islam Baker
 
-Authored By: Fortinet CSE
+Authored By: Fortinet SE KSA 
 
 Certified: No
 ## Installing the connector

--- a/hikvision-nvr/connector.py
+++ b/hikvision-nvr/connector.py
@@ -14,7 +14,7 @@ class hikvision(Connector):
     def execute(self, config, operation, operation_params, **kwargs):
         try:
             operation = operations.get(operation)
-            return operation(config, operation_params)
+            return operation(config, operation_params, **kwargs)
         except Exception as err:
             logger.error('{0}'.format(err))
             raise ConnectorError('{0}'.format(err))

--- a/hikvision-nvr/info.json
+++ b/hikvision-nvr/info.json
@@ -517,6 +517,17 @@
           "required": true,
           "visible": true,
           "editable": true
+        },
+        {
+          "title": "Create FortiSOAR Attachments",
+          "type": "checkbox",
+          "name": "create_fortisoar_attachment",
+          "tooltip": "If the user wants to create an Attachment record in the FortiSAOR attachment module, then select this option. Otherwise, it stores the recording in the /tmp directory",
+          "description": "If the user wants to create an Attachment record in the FortiSAOR attachment module, then select this option. Otherwise, it stores the recording in the /tmp directory",
+          "required": false,
+          "visible": true,
+          "editable": true,
+          "value": false
         }
       ],
       "enabled": true,

--- a/hikvision-nvr/info.json
+++ b/hikvision-nvr/info.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "label": "Hikvision NVR",
   "description": "Hikvision's Network Video Recorders (NVRs) provide advanced artificial intelligence capabilities for any connected data stream, even those from conventional security cameras",
-  "publisher": "Fortinet CSE",
+  "publisher": "Fortinet SE KSA",
   "cs_approved": false,
   "cs_compatible": true,
   "help_online": "https://github.com/fortinet-fortisoar/connector-hikvision-nvr/blob/release/1.0.0/docs/HikvisionNVRDoc.md",

--- a/hikvision-nvr/operations.py
+++ b/hikvision-nvr/operations.py
@@ -13,7 +13,7 @@ import xmltodict
 from connectors.core.connector import get_logger, ConnectorError
 from connectors.cyops_utilities.builtins import upload_file_to_cyops
 from django.conf import settings
-
+from connectors.cyops_utilities.builtins import save_file_in_env
 from .constants import (DEFAULT_EXTENSION, LOG_SEARCH_XML_PAYLOAD, GET_VIDEO_RECORDING_XML_PAYLOAD)
 
 error_msgs = {
@@ -83,19 +83,19 @@ def login(config, params):
     return response
 
 
-def get_channel(config, params):
+def get_channel(config, params, **kwargs):
     hik = hikvision(config)
     endpoint = '/ISAPI/Streaming/channels'
     return hik.make_rest_call(endpoint=endpoint, method='GET')
 
 
-def get_interface(config, params):
+def get_interface(config, params, **kwargs):
     hik = hikvision(config)
     endpoint = '/ISAPI/System/Network/interfaces'
     return hik.make_rest_call(endpoint=endpoint, method='GET')
 
 
-def search_log(config, params):
+def search_log(config, params, **kwargs):
     hik = hikvision(config)
     endpoint = '/ISAPI/ContentMgmt/logSearch'
     start_time = params.get('start_date')
@@ -109,25 +109,25 @@ def search_log(config, params):
     return hik.make_rest_call(endpoint=endpoint, method='POST', data=payload)
 
 
-def get_http_listening_servers(config, params):
+def get_http_listening_servers(config, params, **kwargs):
     hik = hikvision(config)
     endpoint = '/ISAPI/Event/notification/httpHosts'
     return hik.make_rest_call(endpoint=endpoint, method='GET')
 
 
-def get_device_info(config, params):
+def get_device_info(config, params, **kwargs):
     hik = hikvision(config)
     endpoint = '/ISAPI/System/deviceInfo'
     return hik.make_rest_call(endpoint=endpoint, method='GET')
 
 
-def get_ntp_details(config, params):
+def get_ntp_details(config, params, **kwargs):
     hik = hikvision(config)
     endpoint = '/ISAPI/System/time/capabilities'
     return hik.make_rest_call(endpoint=endpoint, method='GET')
 
 
-def get_video_recording_details(config, params):
+def get_video_recording_details(config, params, **kwargs):
     hik = hikvision(config)
     endpoint = '/ISAPI/ContentMgmt/search'
     start_time = params.get('start_date')
@@ -138,7 +138,8 @@ def get_video_recording_details(config, params):
     return hik.make_rest_call(endpoint=endpoint, method='POST', data=payload)
 
 
-def download_video(config, params):
+def download_video(config, params, **kwargs):
+    env = kwargs.get('env', {})
     hik = hikvision(config)
     create_attachment= params.get('create_fortisoar_attachment')
     url = config.get('server_url').replace("http://", "")
@@ -153,6 +154,7 @@ def download_video(config, params):
     path = join(settings.TMP_FILE_ROOT, file_name)
     with open(path, 'wb') as fp:
         fp.write(video_content)
+    save_file_in_env(env, path)
     if create_attachment:
         attach_response = upload_file_to_cyops(file_path=file_name, filename=file_name,
                                            name=file_name, create_attachment=True)

--- a/hikvision-nvr/operations.py
+++ b/hikvision-nvr/operations.py
@@ -140,6 +140,7 @@ def get_video_recording_details(config, params):
 
 def download_video(config, params):
     hik = hikvision(config)
+    create_attachment= params.get('create_fortisoar_attachment')
     url = config.get('server_url').replace("http://", "")
     url_final = url.replace("https://", "")
     file_name = str(params.get('videoname'))
@@ -152,9 +153,12 @@ def download_video(config, params):
     path = join(settings.TMP_FILE_ROOT, file_name)
     with open(path, 'wb') as fp:
         fp.write(video_content)
-    attach_response = upload_file_to_cyops(file_path=file_name, filename=file_name,
+    if create_attachment:
+        attach_response = upload_file_to_cyops(file_path=file_name, filename=file_name,
                                            name=file_name, create_attachment=True)
-    return attach_response
+        return attach_response
+    else:
+        return {'file_name': file_name, 'file_path': path}
 
 
 def _check_health(config):

--- a/hikvision-nvr/operations.py
+++ b/hikvision-nvr/operations.py
@@ -63,16 +63,21 @@ class hikvision(object):
                     return response.content
             else:
                 raise ConnectorError("{0}".format(error_msgs.get(response.status_code), response.text))
-        except requests.exceptions.SSLError:
+        except requests.exceptions.SSLError as err:
+            logger.error("error: {}".format(err))
             raise ConnectorError('SSL certificate validation failed')
-        except requests.exceptions.ConnectTimeout:
+        except requests.exceptions.ConnectTimeout as err:
+            logger.error("error: {}".format(err))
             raise ConnectorError('The request timed out while trying to connect to the server')
-        except requests.exceptions.ReadTimeout:
+        except requests.exceptions.ReadTimeout as err:
+            logger.error("error: {}".format(err))
             raise ConnectorError(
                 'The server did not send any data in the allotted amount of time')
-        except requests.exceptions.ConnectionError:
+        except requests.exceptions.ConnectionError as err:
+            logger.error("error: {}".format(err))
             raise ConnectorError('Invalid endpoint or credentials')
         except Exception as err:
+            logger.error("error: {}".format(err))
             raise ConnectorError(str(err))
 
 

--- a/hikvision-nvr/operations.py
+++ b/hikvision-nvr/operations.py
@@ -14,7 +14,7 @@ from connectors.core.connector import get_logger, ConnectorError
 from connectors.cyops_utilities.builtins import upload_file_to_cyops
 from django.conf import settings
 
-from .constants import (DEFAULT_EXTENSION, LOG_SEARCH_XML_PAYLOAD)
+from .constants import (DEFAULT_EXTENSION, LOG_SEARCH_XML_PAYLOAD, GET_VIDEO_RECORDING_XML_PAYLOAD)
 
 error_msgs = {
     400: 'Bad/Invalid Request',
@@ -106,7 +106,6 @@ def search_log(config, params):
     else:
         metaID = "log.std-cgi.com"
     payload = LOG_SEARCH_XML_PAYLOAD.format(metaID=metaID.strip(), start_time=start_time, end_time=end_time, limit=limit)
-    logger.error("payload: {}".format(payload))
     return hik.make_rest_call(endpoint=endpoint, method='POST', data=payload)
 
 
@@ -135,8 +134,7 @@ def get_video_recording_details(config, params):
     end_time = params.get('enddate')
     trackid = params.get('trackid')
     limit = params.get('limit', '')
-    payload = LOG_SEARCH_XML_PAYLOAD.format(trackid=trackid, start_time=start_time, end_time=end_time, limit=limit)
-    logger.error("payload: {}".format(payload))
+    payload = GET_VIDEO_RECORDING_XML_PAYLOAD.format(trackid=trackid, start_time=start_time, end_time=end_time, limit=limit)
     return hik.make_rest_call(endpoint=endpoint, method='POST', data=payload)
 
 


### PR DESCRIPTION
Following changes added in this PR:
1. Added option new parameter to 'Create FortiSOAR Attachment' 
   - If you select this parameter, it creates an Attachment record in the FortiSAOR attachment module. Otherwise, it stores the recording in the /tmp directory.
2. Remove files from /tmp directory after complete playbook workflow
3. Updated Publisher Details
